### PR TITLE
feat: add API token configuration to

### DIFF
--- a/web/sites/default/settings.fleet.php
+++ b/web/sites/default/settings.fleet.php
@@ -22,3 +22,5 @@ $config['system.performance']['js']['preprocess'] = TRUE;
 
 $settings['reverse_proxy'] = TRUE;
 $settings['reverse_proxy_addresses'] = array($_SERVER['REMOTE_ADDR']);
+
+$config['rest_api_authentication.settings']['api_token'] = getenv('REST_API_TOKEN');


### PR DESCRIPTION
Add configuration for REST API token in settings file to enable  authentication for API requests. This change allows the application  to securely retrieve the token from the environment variable,  enhancing security and flexibility in deployment.