### PR TITLE
Delete all related submissions and votes when a challenge is deleted

### DIFF
--- a/web/modules/custom/wyciwyg_utils/wyciwyg_utils.module
+++ b/web/modules/custom/wyciwyg_utils/wyciwyg_utils.module
@@ -114,3 +114,32 @@ function game_pin_exists($pin, $exclude_nid = NULL) {
 
   return (bool) $query->execute();
 }
+
+/**
+ * Implements hook_entity_delete() to delete all submissions and votes related to a challenge.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being deleted.
+ */
+function wyciwyg_utils_node_delete(Drupal\Core\Entity\EntityInterface $entity) {
+  
+  // Check if the entity is a challenge node
+  if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'challenge') {
+    
+    $nid = $entity->id();
+
+    // Load all submissions and votes related to the challenge
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+    $submissions = $storage->loadByProperties(['type' => 'submission', 'field_challenge_id' => $nid]);
+    $votes = $storage->loadByProperties(['type' => 'vote', 'field_challenge_id' => $nid]);
+
+    // Delete all submissions and votes related to the challenge
+    foreach ($submissions as $submission) {
+      $submission->delete();
+    }
+
+    foreach ($votes as $vote) {
+      $vote->delete();
+    }
+  }
+}

--- a/web/modules/custom/wyciwyg_utils/wyciwyg_utils.module
+++ b/web/modules/custom/wyciwyg_utils/wyciwyg_utils.module
@@ -48,6 +48,12 @@ function wyciwyg_utils_form_alter(&$form, FormStateInterface $form_state, $form_
       $attributes
     );
   }
+
+  // Update the title and description for the challenge delete confirmation form
+  if ($form_id === 'node_challenge_delete_form') {
+    $form['#title'] = t('Are you sure you want to delete this challenge?');
+    $form['description']['#markup'] = t('This will delete the challenge, and all related submissions and votes. This action cannot be undone.');
+  }
 }
 
 /**


### PR DESCRIPTION
Logic to delete all related submissions and votes when a challenge is deleted. 
Custom delte confirmation message added. 